### PR TITLE
* Fix a bug where chalk would display on wrong canvas

### DIFF
--- a/Fishy/Utils/NetworkHandler.cs
+++ b/Fishy/Utils/NetworkHandler.cs
@@ -227,8 +227,12 @@ namespace Fishy.Utils
 
             foreach(Dictionary<Vector2, int> Canvas in Fishy.CanvasData)
             {
-                if (Canvas == null) continue;
-
+                if (Canvas == null)
+                {
+                    i++;
+                    continue;
+                }
+                
                 new ChalkPacket(i, Canvas).SendPacket("single", (int)CHANNELS.CHALK, id);
 
                 i++;


### PR DESCRIPTION
Issue:
1. The player joins a lobby and draws on a canvas with an ID other than 0
2. Rejoin
3. Chalk displays on the wrong canvas