### PR TITLE
Add SpawnActor method

### DIFF
--- a/Fishy/Utils/Spawner.cs
+++ b/Fishy/Utils/Spawner.cs
@@ -112,6 +112,10 @@ namespace Fishy.Utils
         {
             new ActorSpawnPacket(actor.Type, actor.Position, actor.InstanceID).SendPacket("all", (int)CHANNELS.GAME_STATE);
             Fishy.Actors.Add(actor);
+            if (actor.Rotation == default)
+                return;
+            new ActorUpdatePacket(actor.InstanceID, actor.Position, actor.Rotation).SendPacket("all", (int)CHANNELS.GAME_STATE);
+
         }
         public static void SpawnActor(int ID, string Type, Vector3 position, Vector3 entRot = default)
         {

--- a/Fishy/Utils/Spawner.cs
+++ b/Fishy/Utils/Spawner.cs
@@ -52,7 +52,7 @@ namespace Fishy.Utils
             if (_random.NextSingle() < 0.01f && _random.NextSingle() < 0.25)
                 type = "void_portal";
 
-            switch(type)
+            switch (type)
             {
                 case "none":
                     return;
@@ -70,7 +70,7 @@ namespace Fishy.Utils
                 case "void_portal":
                     SpawnVoidPortal();
                     break;
-            }          
+            }
         }
 
         public static void SpawnFish(string type = "fish_spawn")
@@ -80,35 +80,42 @@ namespace Fishy.Utils
             new ActorSpawnPacket(type, pos, id).SendPacket("all", (int)CHANNELS.GAME_STATE);
             Fishy.Actors.Add(new Actor(id, type, pos));
             if (type != "fish_spawn")
-                new ActorRemovePacket(id) { Action = "_ready"}.SendPacket("all", (int)CHANNELS.GAME_STATE);
+                new ActorRemovePacket(id) { Action = "_ready" }.SendPacket("all", (int)CHANNELS.GAME_STATE);
         }
 
         public static void SpawnRainCloud()
         {
             int id = _random.Next();
             Vector3 pos = new(_random.Next(-100, 150), 42f, _random.Next(-150, 100));
-            new ActorSpawnPacket("raincloud", pos, id).SendPacket("all", (int)CHANNELS.GAME_STATE);
-            Fishy.Actors.Add(new RainCloud(id, pos));
+            SpawnActor(new RainCloud(id, pos));
         }
 
         public static void SpawnMetalSpot()
         {
             int id = _random.Next();
-            Vector3 pos =  Fishy.World.TrashPoints[_random.Next(Fishy.World.TrashPoints.Count)];
+            Vector3 pos = Fishy.World.TrashPoints[_random.Next(Fishy.World.TrashPoints.Count)];
 
             if (_random.NextSingle() < .15f)
                 pos = Fishy.World.ShorelinePoints[_random.Next(Fishy.World.ShorelinePoints.Count)];
 
-            new ActorSpawnPacket("metal_spawn", pos, id).SendPacket("all", (int)CHANNELS.GAME_STATE);
-            Fishy.Actors.Add(new Actor(id, "metal_spawn", pos));
+            SpawnActor(new Actor(id, "metal_spawn", pos));
         }
 
         public static void SpawnVoidPortal()
         {
             int id = _random.Next();
             Vector3 pos = Fishy.World.HiddenSpots[_random.Next(Fishy.World.HiddenSpots.Count)];
-            new ActorSpawnPacket("void_portal", pos, id).SendPacket("all", (int)CHANNELS.GAME_STATE);
-            Fishy.Actors.Add(new Actor(id, "void_portal", pos));
+            SpawnActor(new Actor(id, "void_portal", pos));
+        }
+
+        public static void SpawnActor(Actor actor)
+        {
+            new ActorSpawnPacket(actor.Type, actor.Position, actor.InstanceID).SendPacket("all", (int)CHANNELS.GAME_STATE);
+            Fishy.Actors.Add(actor);
+        }
+        public static void SpawnActor(int ID, string Type, Vector3 position, Vector3 entRot = default)
+        {
+            SpawnActor( new Actor(ID, Type, position, entRot));
         }
     }
 }


### PR DESCRIPTION
As an initial disclaimer I do not have a system setup where I have 2 steam accounts, and either 2 computers or a sandboxed environment to join the newly compiled server to verify I have not destroyed it. I can only confirm that it compiles and the server runs. I apologize for the inconvenience but I simply do not have resources, nor time currently to do so.


+ Add the SpawnActor Method to Spawner.cs
+ Modifies several of the methods in Spawner.cs to use SpawnActor where possible rather than repeating lines of code for broadcasting the packet and adding it to the Actor list

The main idea is that SpawnActor can be used as a broader utility method for Extensions/Plugins to spawn more objects anywhere they please, with whatever Actor type they wish assuming that most types work when networked like props, tents etc

It even supports rotation! (Theoretically) 

Whilst true extension plugins could do this anyway before with something like
```cs
  var actor = new Actor(Id, type etc...);
  new ActorSpawnPacket(actor.Type, actor.Position, actor.InstanceID).SendPacket("all", (int)CHANNELS.GAME_STATE);
  Fishy.Actors.Add(actor);
```
it would be simpler to do
```cs
Spawner.SpawnActor(new Actor(Id, type, etc...));
```

I have also reflected these changes in the other methods within Spawner.cs where they would do the afore mentioned, repeated ActorSpawnPacket broadcast stuff and adding the Actors to the Actors list.

I understand that these methods were ported from world.gd initially 

I am rather an idiot when it comes to programming, and etiquette so I would not be surprised if this pull was not up to standards