### PR TITLE
Set CommandHandler and ChatUtils public for plugins

### DIFF
--- a/Fishy/Chat/CommandHandler.cs
+++ b/Fishy/Chat/CommandHandler.cs
@@ -10,7 +10,7 @@ namespace Fishy.Chat
         Server = 100,
     }
 
-    class CommandHandler
+    public class CommandHandler
     {
         public static Dictionary<string, Command> Commands = [];
 

--- a/Fishy/Utils/ChatUtils.cs
+++ b/Fishy/Utils/ChatUtils.cs
@@ -3,7 +3,7 @@ using Fishy.Models.Packets;
 using Steamworks;
 namespace Fishy.Utils
 {
-    internal class ChatUtils
+    public class ChatUtils
     {
         public static void SendChat(SteamId steamId, string message, string color="ffffff")
         {


### PR DESCRIPTION
Was making an extension when I realised I forgot to set these public so I could add commands via extensions, have tested doing so and it works