### PR TITLE
Improve Despawn logic, Minor plugin event touchups, Exploit fixes

### DIFF
--- a/Fishy/Chat/Commands/Moderation.cs
+++ b/Fishy/Chat/Commands/Moderation.cs
@@ -19,7 +19,9 @@ namespace Fishy.Chat.Commands
             Console.WriteLine("Server was halted by " + executor);
 
             new ServerClosePacket().SendPacket("all", (int)CHANNELS.GAME_STATE);
-
+            Fishy.SteamHandler.Lobby.SetJoinable(false); // Prevent takeover of lobby
+            foreach (var pl in Fishy.Players) // Kick all players
+                Punish.KickPlayer(pl);
             Fishy.SteamHandler.Lobby.Leave();
             Environment.Exit(0);
         }

--- a/Fishy/Event/EventManager.cs
+++ b/Fishy/Event/EventManager.cs
@@ -7,36 +7,45 @@ namespace Fishy.Event
    
     public class EventManager
     {
-        public static event EventHandler<Events.ChatMessageEventArgs> OnChatMessage;
-        internal static void RaiseEvent(Events.ChatMessageEventArgs eventArgs)  => OnChatMessage.Invoke(null, eventArgs);
+        public static event EventHandler<EventArgs.ChatMessageEventArgs> OnChatMessage;
+        internal static void RaiseEvent(EventArgs.ChatMessageEventArgs eventArgs)  => OnChatMessage.Invoke(null, eventArgs);
 
 
-        public static event EventHandler<Events.PlayerJoinEventArgs> OnPlayerJoin;
-        internal static void RaiseEvent(Events.PlayerJoinEventArgs  eventArgs)  => OnPlayerJoin.Invoke(null, eventArgs);
+        public static event EventHandler<EventArgs.PlayerJoinEventArgs> OnPlayerJoin;
+        internal static void RaiseEvent(EventArgs.PlayerJoinEventArgs  eventArgs)  => OnPlayerJoin.Invoke(null, eventArgs);
 
 
-        public static event EventHandler<Events.PlayerLeaveEventArgs> OnPlayerLeave;
-        internal static void RaiseEvent(Events.PlayerLeaveEventArgs eventArgs)  => OnPlayerLeave.Invoke(null, eventArgs);
+        public static event EventHandler<EventArgs.PlayerLeaveEventArgs> OnPlayerLeave;
+        internal static void RaiseEvent(EventArgs.PlayerLeaveEventArgs eventArgs)  => OnPlayerLeave.Invoke(null, eventArgs);
 
 
-        public static event EventHandler<Events.ActorSpawnEventArgs> OnActorSpawn;
-        internal static void RaiseEvent(Events.ActorSpawnEventArgs  eventArgs)  => OnActorSpawn.Invoke(null, eventArgs);
+        public static event EventHandler<EventArgs.ActorSpawnEventArgs> OnActorSpawn;
+        internal static void RaiseEvent(EventArgs.ActorSpawnEventArgs  eventArgs)  => OnActorSpawn.Invoke(null, eventArgs);
 
 
-        public static event EventHandler<Events.ActorDespawnEventArgs> OnActorDespawn;
-        internal static void RaiseEvent(Events.ActorDespawnEventArgs eventArgs) => OnActorDespawn.Invoke(null, eventArgs);
+        public static event EventHandler<EventArgs.ActorDespawnEventArgs> OnActorDespawn;
+        internal static void RaiseEvent(EventArgs.ActorDespawnEventArgs eventArgs) => OnActorDespawn.Invoke(null, eventArgs);
 
 
-        public static event EventHandler<Events.ActorActionEventArgs> OnActorAction;
-        internal static void RaiseEvent(Events.ActorActionEventArgs eventArgs) => OnActorAction.Invoke(null, eventArgs);
+        public static event EventHandler<EventArgs.ActorActionEventArgs> OnActorAction;
+        internal static void RaiseEvent(EventArgs.ActorActionEventArgs eventArgs)  => OnActorAction.Invoke(null, eventArgs);
     }
 }
-namespace Fishy.Event.Events
+namespace Fishy.Event.EventArgs
 {
-    public class ActorActionEventArgs(SteamId steamId, string packetAction) : EventArgs
+    public class ActorActionEventArgs(SteamId steamId, string packetAction, Dictionary<string, object> packetInfo) : System.EventArgs
     {
         public SteamId SteamId { get; set; } = steamId;
         public string PacketAction { get; set; } = packetAction;
+
+        public Dictionary<string, object> PacketInfo { get; set; } = packetInfo;
+
+        public Dictionary<int, object> GetParams()
+        {
+            if (PacketInfo.ContainsKey("params"))
+                return (Dictionary<int,object>)PacketInfo["params"];
+            return new Dictionary<int, object>();
+        }
     }
 
     public class ActorSpawnEventArgs(Actor actor)
@@ -49,7 +58,7 @@ namespace Fishy.Event.Events
         public Actor Actor { get; set; } = actor;
     }
 
-    public class ChatMessageEventArgs(SteamId steamId, string message) : EventArgs
+    public class ChatMessageEventArgs(SteamId steamId, string message) : System.EventArgs
     {
         public SteamId SteamId { get; set; } = steamId;
         public string Message { get; set; } = message;
@@ -57,11 +66,11 @@ namespace Fishy.Event.Events
         public ChatMessage ChatMessage { get; set; } = new ChatMessage(steamId, message);
     }
 
-    public class PlayerJoinEventArgs(Player player) : EventArgs
+    public class PlayerJoinEventArgs(Player player) : System.EventArgs
     {
         public Player Player { get; set; } = player;
     }
-    public class PlayerLeaveEventArgs(Player player) : EventArgs
+    public class PlayerLeaveEventArgs(Player player) : System.EventArgs
     {
         public Player Player { get; set; } = player;
     }

--- a/Fishy/Models/Actor.cs
+++ b/Fishy/Models/Actor.cs
@@ -29,7 +29,7 @@ namespace Fishy.Models
         public Vector3 Rotation { get; set; }
 
         public int DespawnTime { get; set; }  = -1;
-        public bool Despawn { get; set; }  = true;
+        public bool Despawn { get; set; }  = false;
 
         public Actor(int ID, ActorType type, Vector3 position, Vector3 entRot = default)
         {

--- a/Fishy/Models/Packets/MessagePacket.cs
+++ b/Fishy/Models/Packets/MessagePacket.cs
@@ -20,7 +20,7 @@ namespace Fishy.Models.Packets
             if (target != "all") return;
             ChatMessage chatMessage = new(SteamClient.SteamId, Message);
             ChatLogger.Log(chatMessage);
-            Event.EventManager.RaiseEvent(new Event.Events.ChatMessageEventArgs(SteamClient.SteamId, Message));
+            Event.EventManager.RaiseEvent(new Event.EventArgs.ChatMessageEventArgs(SteamClient.SteamId, Message));
         }
     }
 

--- a/Fishy/Utils/NetworkHandler.cs
+++ b/Fishy/Utils/NetworkHandler.cs
@@ -79,14 +79,14 @@ namespace Fishy.Utils
 
             try
             {
+                if (Punish.IsBanned(packet.SteamId)) // Don't even bother decompressing packet data if player is banned
+                    return;
+
                 byte[] packetData = GZip.Decompress(packet.Data);
                 Dictionary<string, object> packetInfo = FPacket.FromBytes(packetData);
                 if (!packetInfo.TryGetValue("type", out object? value))
                     return;
                 string packetType = (string)value;
-
-                if (Fishy.BannedUsers.Contains(packet.SteamId.Value.ToString()))
-                    return;
 
                 switch (packetType)
                 {

--- a/Fishy/Utils/NetworkHandler.cs
+++ b/Fishy/Utils/NetworkHandler.cs
@@ -137,7 +137,7 @@ namespace Fishy.Utils
                                 RemoveServerActor(serverInst);
                             }
                         }
-                        EventManager.RaiseEvent(new Event.Events.ActorActionEventArgs(packet.SteamId, packetAction));
+                        EventManager.RaiseEvent(new Event.EventArgs.ActorActionEventArgs(packet.SteamId, packetAction, packetInfo));
                         break;
                     case "request_actors":
                         List<Actor> instances = Fishy.Actors;
@@ -197,7 +197,7 @@ namespace Fishy.Utils
 
             if (CommandHandler.OnMessage(id, message)) return; // Suppress message if command ran
 
-            EventManager.RaiseEvent(new Event.Events.ChatMessageEventArgs(id,message));
+            EventManager.RaiseEvent(new Event.EventArgs.ChatMessageEventArgs(id,message));
         }
 
 

--- a/Fishy/Utils/Punish.cs
+++ b/Fishy/Utils/Punish.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Fishy.Models;
+﻿using Fishy.Models;
 using Fishy.Models.Packets;
+using Steamworks;
 
 namespace Fishy.Utils
 {
@@ -22,5 +18,11 @@ namespace Fishy.Utils
 
         internal static void KickPlayer(Player playerToKick)
             => new KickPacket().SendPacket("single", (int)CHANNELS.GAME_STATE, playerToKick.SteamID);
+
+        internal static bool IsBanned(SteamId id)
+        {
+            return Fishy.BannedUsers.Contains(id.Value.ToString());
+        }
+        
     }
 }

--- a/Fishy/Utils/SteamHandler.cs
+++ b/Fishy/Utils/SteamHandler.cs
@@ -59,9 +59,8 @@ namespace Fishy.Utils
         void SteamMatchmaking_OnLobbyMemberJoined(Lobby Lobby, Friend userJoining)
         {
             // Try to stop spammers from spam joining, spammer get scammed!
-            var existingPlayer = Fishy.Players.FirstOrDefault(p => p.SteamID == userJoining.Id) ?? null;
-            if (existingPlayer != null)
-                return;
+            foreach (var pl in Fishy.Players)
+                if (pl.SteamID == userJoining.Id) return;
 
             UpdatePlayerCount();
             Player player = new(userJoining.Id, userJoining.Name);

--- a/Fishy/Utils/SteamHandler.cs
+++ b/Fishy/Utils/SteamHandler.cs
@@ -1,8 +1,6 @@
-﻿using Fishy.Extensions;
-using Fishy.Models;
+﻿using Fishy.Models;
 using Steamworks;
 using Steamworks.Data;
-using System.Xml.Linq;
 
 namespace Fishy.Utils
 {

--- a/Fishy/Utils/SteamHandler.cs
+++ b/Fishy/Utils/SteamHandler.cs
@@ -61,7 +61,8 @@ namespace Fishy.Utils
             // Try to stop spammers from spam joining, spammer get scammed!
             foreach (var pl in Fishy.Players)
                 if (pl.SteamID == userJoining.Id) return;
-
+            if (Punish.IsBanned(userJoining.Id)) // Well, that's the best I can do
+                return;
             UpdatePlayerCount();
             Player player = new(userJoining.Id, userJoining.Name);
 
@@ -87,6 +88,7 @@ namespace Fishy.Utils
 
         void SteamMatchmaking_OnP2PSessionRequest(SteamId id)
         {
+            if (Punish.IsBanned(id)) return;
             if (Lobby.Members.Any(player => player.Id.Value.Equals(id)))
                 SteamNetworking.AcceptP2PSessionWithUser(id);
         }

--- a/Fishy/Utils/SteamHandler.cs
+++ b/Fishy/Utils/SteamHandler.cs
@@ -66,7 +66,7 @@ namespace Fishy.Utils
 
             Fishy.Players.Add(player);
 
-            Event.EventManager.RaiseEvent(new Event.Events.PlayerJoinEventArgs(player));
+            Event.EventManager.RaiseEvent(new Event.EventArgs.PlayerJoinEventArgs(player));
 
             Console.Title = $"Fishy Server - There are currently {Fishy.Players.Count} Players playing";
         }
@@ -76,7 +76,7 @@ namespace Fishy.Utils
             UpdatePlayerCount();
             Console.WriteLine(DateTime.Now.ToString("dd.MM HH:mm:ss") + $" A Player Left: {userLeaving.Name}");
 
-            Event.EventManager.RaiseEvent(new Event.Events.PlayerLeaveEventArgs(Fishy.Players.First(player => player.SteamID.Equals(userLeaving.Id))));
+            Event.EventManager.RaiseEvent(new Event.EventArgs.PlayerLeaveEventArgs(Fishy.Players.First(player => player.SteamID.Equals(userLeaving.Id))));
 
             Fishy.Players.RemoveAll(player => player.SteamID.Equals(userLeaving.Id));
             Console.Title = $"Fishy Server - There are currently {Fishy.Players.Count} Players playing";

--- a/Fishy/Utils/SteamHandler.cs
+++ b/Fishy/Utils/SteamHandler.cs
@@ -2,6 +2,7 @@
 using Fishy.Models;
 using Steamworks;
 using Steamworks.Data;
+using System.Xml.Linq;
 
 namespace Fishy.Utils
 {
@@ -59,6 +60,11 @@ namespace Fishy.Utils
 
         void SteamMatchmaking_OnLobbyMemberJoined(Lobby Lobby, Friend userJoining)
         {
+            // Try to stop spammers from spam joining, spammer get scammed!
+            var existingPlayer = Fishy.Players.FirstOrDefault(p => p.SteamID == userJoining.Id) ?? null;
+            if (existingPlayer != null)
+                return;
+
             UpdatePlayerCount();
             Player player = new(userJoining.Id, userJoining.Name);
 

--- a/FishyWebserver/WebserverExtension.cs
+++ b/FishyWebserver/WebserverExtension.cs
@@ -10,11 +10,11 @@ namespace Fishy.Webserver
             => GetConfigValue("webserver")["username"].ToString() ?? "";
         public static string GetPassword()
             => GetConfigValue("webserver")["password"].ToString() ?? "";
-        public static void OnChatMessage(object? sender, Event.Events.ChatMessageEventArgs args)
+        public static void OnChatMessage(object? sender, Event.EventArgs.ChatMessageEventArgs args)
             => dashboard.MessageToSync.Add(args.ChatMessage);
-        public static void OnPlayerJoin(object? sender,Event.Events.PlayerJoinEventArgs args)
+        public static void OnPlayerJoin(object? sender,Event.EventArgs.PlayerJoinEventArgs args)
             => dashboard.PlayersToSync.TryAdd(args.Player, "join");
-        public static void OnPlayerLeave(object? sender, Event.Events.PlayerLeaveEventArgs args)
+        public static void OnPlayerLeave(object? sender, Event.EventArgs.PlayerLeaveEventArgs args)
             => dashboard.PlayersToSync.TryAdd(args.Player, "leave");
         public override void OnInit()
         { 


### PR DESCRIPTION
Changed the despawn system so that it uses the Actor class's Despawn, and DespawnTime fields rather than a large if statement responsible for checking all the despawn times

Also changed namespace name for eventargs from Event.Events to Event.EventArgs as I realised that wasn't so intuitive

Also also, added a last minute check to attempt to fix a recent issue where malicious users could spam the Steam Join Lobby event to fill a server's lobby with the same player